### PR TITLE
Validate install path against macOS TCC-protected directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Or specify where to install (defaults to `~/hyperagent`):
 bash <(curl -sL -H "Accept: application/vnd.github.raw" https://api.github.com/repos/bioneural/graft/contents/bootstrap.sh) ~/repos/hyperagent
 ```
 
+**Note (macOS):** The install directory must not be under `~/Desktop`, `~/Documents`, or `~/Downloads`. These are TCC-protected directories that LaunchAgents cannot access. Use the default (`~/hyperagent`) or another path outside those directories.
+
 This downloads the specification, delivers it to Claude Code, and Claude Code constructs a private `hyperagent` repo under your GitHub account. The install script configures hooks and starts the watcher as a system service. Restart Claude Code once. The system is operational.
 
 ---

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,6 +3,22 @@ set -euo pipefail
 
 INSTALL_DIR="${1:-$HOME/hyperagent}"
 
+# --- TCC directory check (macOS) ---
+check_tcc_safe() {
+    if [ "$(uname)" != "Darwin" ]; then return 0; fi
+    local resolved
+    resolved=$(cd "$1" 2>/dev/null && pwd -P || echo "$1")
+    case "$resolved" in
+        "$HOME/Desktop"*|"$HOME/Documents"*|"$HOME/Downloads"*)
+            echo "ERROR: $1 is under a macOS TCC-protected directory."
+            echo "LaunchAgents cannot access ~/Desktop, ~/Documents, or ~/Downloads."
+            echo "Use a path outside these directories, e.g. ~/hyperagent"
+            exit 1
+            ;;
+    esac
+}
+check_tcc_safe "$INSTALL_DIR"
+
 echo "=== Graft: bootstrapping your hyperagent ==="
 echo ""
 echo "Install directory: $INSTALL_DIR"

--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -836,6 +836,22 @@ set -euo pipefail
 HYPERAGENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLAUDE_DIR="$HOME/.claude"
 
+# --- TCC directory check (macOS) ---
+check_tcc_safe() {
+    if [ "$(uname)" != "Darwin" ]; then return 0; fi
+    local resolved
+    resolved=$(cd "$1" 2>/dev/null && pwd -P || echo "$1")
+    case "$resolved" in
+        "$HOME/Desktop"*|"$HOME/Documents"*|"$HOME/Downloads"*)
+            echo "ERROR: $1 is under a macOS TCC-protected directory."
+            echo "LaunchAgents cannot access ~/Desktop, ~/Documents, or ~/Downloads."
+            echo "Use a path outside these directories, e.g. ~/hyperagent"
+            exit 1
+            ;;
+    esac
+}
+check_tcc_safe "$HYPERAGENT_DIR"
+
 echo "=== Installing Hyperagent ==="
 
 # Prerequisites


### PR DESCRIPTION
## Summary

- Adds `check_tcc_safe()` to `bootstrap.sh` and the `install.sh` spec that detects TCC-protected paths (`~/Desktop`, `~/Documents`, `~/Downloads`) on macOS and exits with a clear error before anything is installed
- Documents the restriction in the README

Closes #1