### PR TITLE
Add /hyperagent-upgrade skill and graft version tracking

### DIFF
--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -29,6 +29,7 @@ hyperagent/
 │   ├── hyperagent-status/SKILL.md  # /hyperagent-status skill. §3.
 │   ├── hyperagent-issue/SKILL.md  # /hyperagent-issue skill. §3.
 │   └── hyperagent-upgrade/SKILL.md # /hyperagent-upgrade skill. §3.
+├── .graft-version             # Graft commit SHA this hyperagent was generated from.
 ├── install.sh                 # Sets up integration points. §10.
 ├── uninstall.sh               # Removes integration points. §11.
 ├── .gitignore                 # §2.
@@ -226,11 +227,14 @@ Your hyperagent is an independent implementation generated from the Graft bluepr
    gh api repos/bioneural/graft/commits --jq '.[0:20] | .[] | "\(.sha[0:7]) \(.commit.message | split("\n")[0])"'
    ```
 
-2. Check if there's a local marker for the last reviewed commit:
+2. Determine the baseline. Check these in order:
+   - `<hyperagent_dir>/.last-upgrade-check` — the last reviewed commit (set by previous upgrade runs)
+   - `<hyperagent_dir>/.graft-version` — the graft commit this hyperagent was generated from
+
    ```bash
-   cat <hyperagent_dir>/.last-upgrade-check 2>/dev/null
+   BASELINE=$(cat <hyperagent_dir>/.last-upgrade-check 2>/dev/null || cat <hyperagent_dir>/.graft-version 2>/dev/null)
    ```
-   If the marker exists, only show commits newer than that SHA. If not, show the 10 most recent.
+   If a baseline exists, only show commits newer than that SHA. If neither file exists, show the 10 most recent.
 
 3. For each new commit, fetch the diff:
    ```bash
@@ -255,7 +259,7 @@ Your hyperagent is an independent implementation generated from the Graft bluepr
 
 ## Part 2: Contribute Back to Graft
 
-7. Review local changes that diverge from the blueprint. Compare key files against the upstream spec:
+7. Review local changes that diverge from the blueprint. The generation baseline is in `<hyperagent_dir>/.graft-version` — this is the graft commit the hyperagent was originally built from. Compare key files against the upstream spec at that baseline and at HEAD to distinguish local customizations from upstream drift:
    - `meta_agent.md` — has the meta agent evolved strategies worth sharing?
    - `skills/` — any new skills or significant skill improvements?
    - `tools/` — any tools that solve common problems?

--- a/implement-hyperagent.md
+++ b/implement-hyperagent.md
@@ -51,6 +51,14 @@ Create every file listed in §1 of the spec, with the exact contents specified i
 15. `install.sh` — §10. Mark executable.
 16. `uninstall.sh` — §11. Mark executable.
 
+After creating all files, stamp the graft version used to generate the hyperagent:
+
+```bash
+gh api repos/bioneural/graft/commits --jq '.[0].sha' > .graft-version
+```
+
+This records which graft commit the hyperagent was generated from. The `/hyperagent-upgrade` skill uses it as the baseline for diffing upstream changes.
+
 Do NOT create runtime files (`ledger`, `.last-check`, `.lock`, `.last-change`, `.heartbeat`, `.seen/`). These are created by `install.sh` or at runtime.
 
 ## Step 3: Create the README
@@ -129,7 +137,7 @@ cd INSTALL_DIR
 for f in .gitignore meta_agent.md watcher.sh memory.md changelog.md \
          hooks/on-session-start.sh hooks/on-prompt.sh \
          skills/hyperagent-reload/SKILL.md skills/hyperagent-changelog/SKILL.md skills/hyperagent-revert/SKILL.md skills/hyperagent-status/SKILL.md skills/hyperagent-issue/SKILL.md skills/hyperagent-upgrade/SKILL.md \
-         install.sh uninstall.sh README.md tools/.gitkeep; do
+         install.sh uninstall.sh README.md tools/.gitkeep .graft-version; do
     [ -f "$f" ] || { echo "MISSING: $f"; exit 1; }
 done
 
@@ -147,6 +155,9 @@ done
 for f in skills/hyperagent-changelog/SKILL.md skills/hyperagent-revert/SKILL.md skills/hyperagent-status/SKILL.md skills/hyperagent-issue/SKILL.md skills/hyperagent-upgrade/SKILL.md; do
     grep -q "hyperagent.json" "$f" || { echo "MISSING CONFIG REFERENCE: $f"; exit 1; }
 done
+
+# .graft-version contains a commit SHA
+grep -qE '^[0-9a-f]{40}$' .graft-version || { echo "FAIL: .graft-version missing or invalid"; exit 1; }
 
 # No python references
 grep -r "python3\|python" --include="*.sh" --include="*.md" . && { echo "FAIL: python reference found"; exit 1; } || true


### PR DESCRIPTION
## Summary

- **`/hyperagent-upgrade` skill**: Bidirectional — pulls blueprint updates from graft into the local hyperagent, and surfaces local improvements worth contributing back as issues or PRs on graft.
- **`.graft-version` baseline**: The implement guide stamps the graft commit SHA at generation time. The upgrade skill uses this to distinguish local customizations from upstream changes.
- **README ownership messaging**: Makes clear that each hyperagent is independently owned — generated from the blueprint, not a fork of it.

## Test plan

- [x] New skill references `hyperagent.json` for path resolution
- [x] Upgrade skill checks `.last-upgrade-check` then falls back to `.graft-version` as baseline
- [x] `.graft-version` added to repo structure, file list, and validation in implement guide
- [x] `.last-upgrade-check` added to `.gitignore` spec
- [x] README describes ownership and `/hyperagent-upgrade`

Closes #3