### PR TITLE
Fix watcher.sh path resolution under launchd

### DIFF
--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -1023,6 +1023,8 @@ if [ "$(uname)" = "Darwin" ]; then
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>WorkingDirectory</key>
+    <string>$HYPERAGENT_DIR</string>
     <key>StandardOutPath</key>
     <string>/tmp/hyperagent.log</string>
     <key>StandardErrorPath</key>
@@ -1045,6 +1047,7 @@ After=default.target
 [Service]
 Type=simple
 ExecStart=$HYPERAGENT_DIR/watcher.sh
+WorkingDirectory=$HYPERAGENT_DIR
 Restart=on-failure
 RestartSec=10
 


### PR DESCRIPTION
## Summary

- Add `WorkingDirectory` to the launchd plist so macOS sets the cwd before launching watcher.sh
- Add `WorkingDirectory` to the systemd unit for consistency

The root cause is that launchd defaults to `/` as the working directory when no `WorkingDirectory` key is set. If path resolution fails after this fix, the correct behavior is to fail fast — not silently fall back.

Closes #7