### PR TITLE
Wrap issue template diagnostic sections in details blocks

### DIFF
--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -194,13 +194,19 @@ The user wants to report a problem with the hyperagent system. Collect context a
 - Watcher heartbeat: <age or "missing">
 - Meta agent modified: <yes/no>
 
-## Recent changelog
+<details>
+<summary>Recent changelog</summary>
 
 <last 5 entries>
 
-## Watcher log (last 20 lines)
+</details>
+
+<details>
+<summary>Watcher log (last 20 lines)</summary>
 
 <log tail or "no log found">
+
+</details>
 ```
 ```
 


### PR DESCRIPTION
## Summary

- Wraps the "Recent changelog" and "Watcher log" sections of the `/hyperagent-issue` body format template in HTML `<details>` blocks
- Diagnostic sections are collapsed by default, reducing noise for general feature requests while remaining expandable for watcher/meta-agent bug reports
- Template-only change; no logic affected

Closes #9