### PR TITLE
Remove disable-model-invocation from hyperagent-issue skill

### DIFF
--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -157,7 +157,6 @@ Format the output clearly. If the watcher is not running, tell the user how to r
 ---
 name: hyperagent-issue
 description: File an issue on the Graft repo with system context. Use when the user reports a problem with the hyperagent, or says "file an issue", "report a bug", or similar.
-disable-model-invocation: true
 ---
 # File a Graft Issue
 


### PR DESCRIPTION
## Summary

- Remove `disable-model-invocation: true` from the `/hyperagent-issue` skill frontmatter so agents can invoke it programmatically.
- Enables diagnostic workflows (e.g., `/hyperagent-status`) to chain into issue filing when persistent problems are detected.

Closes #19