### PR TITLE
Fix watcher auth: remove --bare/--max-turns, add plist env vars

### DIFF
--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -648,9 +648,7 @@ run_meta_agent() {
         RECENT_TRANSCRIPTS="$recent" \
         claude -p "Read your instructions from $META_AGENT and execute your procedure." \
             --allowedTools "Read,Write,Edit,Bash,Glob,Grep" \
-            --max-turns 200 \
             --output-format json \
-            --bare \
             2>/dev/null) || true
 
     # Cancel the watchdog if we finished in time
@@ -739,8 +737,6 @@ Here is the git diff of your changes for reference:
 $diff_summary" \
                 --resume "$session_id" \
                 --allowedTools "Read,Write,Edit" \
-                --max-turns 5 \
-                --bare \
                 2>/dev/null || true
         fi
 
@@ -1128,6 +1124,13 @@ if [ "$(uname)" = "Darwin" ]; then
     <string>/tmp/hyperagent.log</string>
     <key>StandardErrorPath</key>
     <string>/tmp/hyperagent.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>$HOME</string>
+        <key>PATH</key>
+        <string>$PATH</string>
+    </dict>
 </dict>
 </plist>
 PLISTEOF


### PR DESCRIPTION
## Summary

- Remove `--bare` from both `claude` invocations in `run_meta_agent`. This flag disables OAuth and keychain reads, breaking all watcher installations using the default auth method.
- Remove `--max-turns` from both invocations. The flag no longer exists in recent Claude Code CLI versions.
- Add `EnvironmentVariables` dict (`HOME`, `PATH`) to the launchd plist template, populated from the user's environment at install time. Without these, launchd's minimal environment prevents auth credential discovery and binary resolution.

Closes #17
Closes #18