### PR TITLE
Prune stale ledger entries in watcher

### DIFF
--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -673,6 +673,33 @@ check_upstream_upgrade() {
     fi
 }
 
+cleanup_ledger() {
+    # Remove ledger entries for transcripts not modified in 48+ hours
+    # that have already been successfully processed
+    local tmp_ledger="$LEDGER.tmp"
+    local now
+    now=$(now_epoch)
+    local cutoff=$((now - 172800))  # 48 hours
+
+    while IFS=$'\t' read -r path current_mtime processed_mtime; do
+        # Keep if processed_mtime differs from current_mtime (not yet processed)
+        if [ "$current_mtime" != "$processed_mtime" ]; then
+            printf '%s\t%s\t%s\n' "$path" "$current_mtime" "$processed_mtime" >> "$tmp_ledger"
+            continue
+        fi
+        # Keep if modified recently
+        if [ "$current_mtime" -gt "$cutoff" ] 2>/dev/null; then
+            printf '%s\t%s\t%s\n' "$path" "$current_mtime" "$processed_mtime" >> "$tmp_ledger"
+        fi
+    done < "$LEDGER"
+
+    if [ -f "$tmp_ledger" ]; then
+        mv "$tmp_ledger" "$LEDGER"
+    else
+        : > "$LEDGER"
+    fi
+}
+
 run_meta_agent() {
     local trigger_transcript="$1"
     local recent
@@ -805,6 +832,7 @@ $diff_summary" \
 
     # Periodic cleanup
     cleanup_seen
+    cleanup_ledger
 }
 
 # --- Main loop ---


### PR DESCRIPTION
## Summary

- Add `cleanup_ledger` function to `watcher.sh` spec (section 6) that removes ledger entries for transcripts not modified in 48+ hours that have already been successfully processed
- Call `cleanup_ledger` alongside existing `cleanup_seen` in the periodic cleanup step of `run_meta_agent`
- Mirrors the existing `cleanup_seen` pattern for consistency

Closes #25