### PR TITLE
Cap transcripts processed per watcher cycle

### DIFF
--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -527,6 +527,7 @@ SEEN_DIR="$HYPERAGENT_DIR/.seen"
 CHANGELOG="$HYPERAGENT_DIR/changelog.md"
 IDLE_THRESHOLD=300
 CHECK_INTERVAL=60
+MAX_TRANSCRIPTS_PER_CYCLE="${MAX_TRANSCRIPTS_PER_CYCLE:-5}"
 META_AGENT="$HYPERAGENT_DIR/meta_agent.md"
 
 touch "$LEDGER" "$MARKER"
@@ -780,8 +781,15 @@ while true; do
     )
     all_transcripts=$(echo "$all_transcripts" | sort -u | grep -v '^$' || true)
 
+    processed_this_cycle=0
+
     for transcript in $all_transcripts; do
         [ -f "$transcript" ] || continue
+
+        if [ "$processed_this_cycle" -ge "$MAX_TRANSCRIPTS_PER_CYCLE" ]; then
+            log "Cycle cap reached ($MAX_TRANSCRIPTS_PER_CYCLE), deferring remaining transcripts"
+            break
+        fi
 
         current_mtime=$(get_mtime "$transcript")
         entry=$(get_ledger_entry "$transcript")
@@ -816,6 +824,8 @@ while true; do
         release_lock
 
         set_ledger_entry "$transcript" "$current_mtime" "0"
+        processed_this_cycle=$((processed_this_cycle + 1))
+        date +%s > "$HEARTBEAT"
     done
 
     sleep "$CHECK_INTERVAL"


### PR DESCRIPTION
## Summary

- Add `MAX_TRANSCRIPTS_PER_CYCLE` variable (default 5) to limit how many transcripts the watcher processes before returning to the top of the main loop.
- Insert a cycle-cap check at the top of the transcript iteration. When the cap is reached, remaining transcripts are deferred to subsequent cycles.
- Update the heartbeat after each transcript is processed, keeping it fresh during multi-transcript cycles.