### PR TITLE
Redesign /hyperagent-reload: classify and dispatch, not kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Examples of what a change might look like:
 - Creating a skill to automate a manual pattern.
 - Rewriting the meta agent's own instructions, because it found a better method of analysis.
 
-The next message you send, or the next session you start, a single line appears: what changed and whether `/hyperagent-reload` is needed. Each session tracks what it has already seen. No repetition. No interruption.
+The next message you send, or the next session you start, a single line appears: what changed and whether action is needed. Each session tracks what it has already seen. No repetition. No interruption.
 
 If a change degrades performance, the meta agent detects the regression on subsequent cycles and reverts it. You may also invoke `/hyperagent-revert` at any time. Every modification is recorded with a full diff in the changelog. Nothing is irreversible.
 
@@ -114,7 +114,7 @@ For project files: changes are committed with author `Hyperagent <hyperagent@loc
 
 Five skills are provided:
 
-- `/hyperagent-reload` — restart Claude Code to apply configuration changes.
+- `/hyperagent-reload` — review and apply hyperagent changes without restarting.
 - `/hyperagent-changelog` — display recent modifications.
 - `/hyperagent-revert` — roll back a specific change.
 - `/hyperagent-status` — check whether the watcher is running and show recent activity.

--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -68,11 +68,21 @@ Skills that reference the hyperagent repo directory do so by reading `~/.claude/
 ```markdown
 ---
 name: hyperagent-reload
-description: Reload Claude Code to pick up CLAUDE.md changes. Use when the hyperagent notifies you of configuration updates.
-disable-model-invocation: true
+description: Check for and apply hyperagent configuration changes. Use when the hyperagent notifies you of updates.
 ---
-# Reload Claude Code
-!`kill -HUP $PPID`
+# Apply Hyperagent Changes
+
+First, read `~/.claude/hyperagent.json` to get the `hyperagent_dir` path. Use that path for all file references below.
+
+1. Read the hyperagent changelog at `<hyperagent_dir>/changelog.md`. Identify entries newer than the last reload (or all entries if this is the first run).
+2. For each change, classify it:
+   - **Hooks or permissions in `settings.json`** — already live via file watcher. Report as applied.
+   - **Skills or agents** — already live via hot-reload. Report as applied.
+   - **CLAUDE.md or rules files** — report what changed. These will take effect on the next `/compact` or session start.
+   - **MCP server configurations** — report that a session restart is required. Do not terminate the session.
+3. Summarize: list each change, its category, and its reload status.
+4. If CLAUDE.md or rules were modified, tell the user: "These changes will take effect on the next /compact or session start."
+5. If MCP servers were modified, tell the user: "MCP changes require a session restart. Run claude --resume when ready."
 ```
 
 ### `skills/hyperagent-changelog/SKILL.md`
@@ -117,7 +127,7 @@ First, read `~/.claude/hyperagent.json` to get the `hyperagent_dir` path. Use th
    - Run `git log --author="Hyperagent" --oneline` in the project repo to find the corresponding commit.
    - Run `git revert <hash> --no-edit` in the project repo.
 8. Append a revert entry to `<hyperagent_dir>/changelog.md` documenting what was reverted and why.
-9. Tell the user to `/hyperagent-reload` if a CLAUDE.md file was affected.
+9. Tell the user to `/hyperagent-reload` to review what changed.
 ```
 
 ### `skills/hyperagent-status/SKILL.md`
@@ -303,7 +313,7 @@ Your hyperagent is an independent implementation generated from the Graft bluepr
     rm -f <hyperagent_dir>/.upgrade-available
     ```
 
-12. Tell the user to `/hyperagent-reload` if any CLAUDE.md or hook files were affected.
+12. Tell the user to `/hyperagent-reload` to review what changed.
 
 If the user provides arguments: $ARGUMENTS — use them to filter (e.g. "just pull", "just contribute", "last 3 commits", "show everything").
 ```
@@ -401,7 +411,7 @@ When you create a new tool, also ensure it is referenced from wherever it needs 
 6. If a change is warranted, make it. See "Where to write" below.
 7. Update $HYPERAGENT_DIR/memory.md with what you observed, what you changed, your hypothesis, and what to look for next. Only write to memory when you have made a change or have a genuinely new insight worth recording.
 8. Write a summary to stdout. Use one of these prefixes so the watcher knows what happened:
-   - `NOTIFY_RELOAD: <tl;dr>` — a CLAUDE.md or rules file was changed, user should /hyperagent-reload
+   - `NOTIFY_RELOAD: <tl;dr>` — a CLAUDE.md or rules file was changed, user should /hyperagent-reload to review
    - `NOTIFY_SKILL: <tl;dr>` — a skill was created or modified, no reload needed (hot-reload)
    - `NOTIFY_INFO: <tl;dr>` — informational, no action needed from user
    - No output if no changes were made.
@@ -1064,7 +1074,7 @@ if [ "$CHANGE_EPOCH" -gt "$SEEN_EPOCH" ] 2>/dev/null; then
     echo "$CHANGE_EPOCH" > "$SEEN_DIR/$SESSION_ID"
 
     if [ "$CHANGE_TYPE" = "reload" ]; then
-        echo "{\"additionalContext\": \"[Hyperagent] $CHANGE_TLDR. Run /hyperagent-reload to apply, /hyperagent-changelog for details.\"}"
+        echo "{\"additionalContext\": \"[Hyperagent] $CHANGE_TLDR. Run /hyperagent-reload to review, /hyperagent-changelog for details.\"}"
     elif [ "$CHANGE_TYPE" = "skill" ]; then
         echo "{\"additionalContext\": \"[Hyperagent] $CHANGE_TLDR. Already available (no reload needed). /hyperagent-changelog for details.\"}"
     elif [ "$CHANGE_TYPE" = "error" ]; then
@@ -1141,7 +1151,7 @@ if [ "$CHANGE_EPOCH" -gt "$SEEN_EPOCH" ] 2>/dev/null; then
     echo "$CHANGE_EPOCH" > "$SEEN_DIR/$SESSION_ID"
 
     if [ "$CHANGE_TYPE" = "reload" ]; then
-        echo "{\"additionalContext\": \"[Hyperagent] $CHANGE_TLDR. Run /hyperagent-reload to apply, /hyperagent-changelog for details.\"}"
+        echo "{\"additionalContext\": \"[Hyperagent] $CHANGE_TLDR. Run /hyperagent-reload to review, /hyperagent-changelog for details.\"}"
     elif [ "$CHANGE_TYPE" = "skill" ]; then
         echo "{\"additionalContext\": \"[Hyperagent] $CHANGE_TLDR. Already available (no reload needed). /hyperagent-changelog for details.\"}"
     elif [ "$CHANGE_TYPE" = "error" ]; then

--- a/implement-hyperagent.md
+++ b/implement-hyperagent.md
@@ -100,7 +100,7 @@ Restart Claude Code to pick up the hooks. The watcher runs as a system service �
 
 ## Skills
 
-- `/hyperagent-reload` — restart Claude Code to pick up CLAUDE.md changes
+- `/hyperagent-reload` — review and apply hyperagent configuration changes without restarting
 - `/hyperagent-changelog` — show recent hyperagent changes
 - `/hyperagent-revert` — roll back a specific hyperagent change
 - `/hyperagent-status` — check watcher health and recent activity


### PR DESCRIPTION
## Summary

`/hyperagent-reload` sent `kill -HUP $PPID`, terminating the session. Claude Code does not interpret SIGHUP as reload. The user was forced to manually `--resume`.

This replaces the signal with a classification-and-dispatch model:

- **Hooks / permissions in `settings.json`** — already live via file watcher. Reported as applied.
- **Skills / agents** — already live via hot-reload. Reported as applied.
- **CLAUDE.md / rules** — reported as pending; takes effect on next `/compact` or session start.
- **MCP server configs** — reported as requiring session restart. The skill never terminates the session itself.

All references to "restart" and "apply" in notification hooks, README, and implementation guide updated to reflect the new behavior.

## Changes

- `hyperagent-spec.md` — rewrote reload skill from single `kill` command to multi-step classify/dispatch/report. Updated notification hook messages and skill cross-references.
- `implement-hyperagent.md` — updated skill description.
- `README.md` — updated reload skill description and notification language.

## Verification

These are spec and documentation changes. Verification occurs when the hyperagent is next installed or reinstalled from this blueprint — the generated skill file will contain the new logic instead of `kill -HUP`.

Closes #33