### PR TITLE
Pull remote changes before each watcher cycle

### DIFF
--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -601,6 +601,16 @@ resolve_project_path() {
     fi
 }
 
+pull_fast_forward() {
+    local repo_dir="$1"
+    if [ -z "$repo_dir" ] || [ ! -d "$repo_dir/.git" ]; then
+        return
+    fi
+    cd "$repo_dir"
+    git fetch 2>/dev/null || true
+    git merge --ff-only 2>/dev/null || true
+}
+
 commit_hyperagent_repo() {
     local tl_dr="$1"
     cd "$HYPERAGENT_DIR"
@@ -620,6 +630,7 @@ commit_project_repo() {
         return
     fi
     cd "$project_path"
+    pull_fast_forward "$project_path"
     if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
         git add -A
         git commit --author="Hyperagent <hyperagent@local>" \
@@ -840,6 +851,9 @@ $diff_summary" \
 while true; do
     # Write heartbeat so hooks and /hyperagent-status can detect a stalled watcher
     date +%s > "$HEARTBEAT"
+
+    # Pull remote changes so the watcher operates on up-to-date state
+    pull_fast_forward "$HYPERAGENT_DIR"
 
     # Periodic upstream upgrade check
     check_upstream_upgrade


### PR DESCRIPTION
## Summary

The watcher pushes but never pulls. Changes made from another machine — or manually, such as compacting the changelog — are silently ignored. The watcher continues operating on stale local state.

This adds `pull_fast_forward()`: a `git fetch && git merge --ff-only` executed at two points:

- **Top of the main loop** — synchronizes `$HYPERAGENT_DIR` before each cycle begins
- **Inside `commit_project_repo()`** — synchronizes the project repo before committing

Fast-forward only. No merge conflicts. Silent failure on unreachable remotes — the cycle proceeds regardless.

Closes #35