### PR TITLE
Teach the meta agent what silence means

### DIFF
--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -991,6 +991,10 @@ Lessons from Anthropic's internal skill management (source: "Lessons from Buildi
 - **Persistent skill memory.** Skills may need cross-session state (logs, JSON, SQLite). Consider when building skills that learn from repeated use.
 - **Curation before distribution.** Experimental skills should prove their value before becoming permanent. Remove or consolidate skills that underperform.
 
+## Gotchas
+
+- **Do not maintain a cycle counter or per-cycle bookkeeping.** In early runs the meta agent invented a cycle counter in this file, bumping it every cycle even with no findings. Because the watcher commits whenever `git status --porcelain` is non-empty, this produced 63 consecutive no-op commits and 1,142 lines of changelog noise. Step 5 of the procedure means it: if nothing is actionable, do not touch any file — including this one. A silent exit is correct.
+
 ## Observations
 
 _No observations yet._


### PR DESCRIPTION
## Summary

The meta agent invented a cycle counter. It wrote to memory.md every cycle — even cycles with no findings. The watcher commits on any dirty file. The result: 63 no-op commits. 1,142 lines of changelog noise. Procedure step 5 already forbids this. The agent did not listen.

The fix is not more instruction text. It is a gotcha — seeded in memory.md, the file the agent reads first each cycle. Built from the actual failure: what happened, why it was destructive, what correct silence looks like.

- Adds a Gotchas section to the initial `memory.md` content
- No changes to procedure instructions (already correct) or watcher logic (the agent must learn, not be overridden)

The procedure was correct. The agent needed the lesson where it looks.

Closes #36