### PR TITLE
Stop watcher no-op cycles from burning meta-agent tokens (#58)

### DIFF
--- a/hyperagent-spec.md
+++ b/hyperagent-spec.md
@@ -749,10 +749,37 @@ pull_fast_forward() {
     git merge --ff-only 2>/dev/null || true
 }
 
+# Returns porcelain output minus paths listed in §2 .gitignore. The watcher
+# uses this — not raw `git status --porcelain` — to decide whether anything
+# meaningful changed. Filtering here (rather than relying solely on .gitignore)
+# self-heals the pathology where state files committed under an older
+# .gitignore stay tracked forever, keeping the repo permanently dirty and
+# triggering a no-op changelog Claude session every cycle.
+meaningful_changes() {
+    cd "$HYPERAGENT_DIR"
+    git status --porcelain 2>/dev/null | awk '
+        {
+            path = substr($0, 4)
+            sub(/.* -> /, "", path)
+        }
+        path == "ledger"               { next }
+        path == ".last-check"          { next }
+        path == ".lock"                { next }
+        path == ".heartbeat"           { next }
+        path == ".last-change"         { next }
+        path == ".last-upgrade-check"  { next }
+        path == ".upgrade-available"   { next }
+        path == ".last-upstream-poll"  { next }
+        path ~ /^\.seen\//             { next }
+        path ~ /^discussions\//        { next }
+        { print }
+    '
+}
+
 commit_hyperagent_repo() {
     local tl_dr="$1"
     cd "$HYPERAGENT_DIR"
-    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    if [ -n "$(meaningful_changes)" ]; then
         git add -A
         git commit --author="Hyperagent <hyperagent@local>" \
             -m "[hyperagent] ${tl_dr:-auto-commit}" \
@@ -905,8 +932,7 @@ run_meta_agent() {
     # --- Phase 2: Check if anything changed ---
 
     local hyperagent_changed=""
-    cd "$HYPERAGENT_DIR"
-    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    if [ -n "$(meaningful_changes)" ]; then
         hyperagent_changed="yes"
     fi
 
@@ -1521,6 +1547,25 @@ if [ ! -d "$HYPERAGENT_DIR/.git" ]; then
     git -C "$HYPERAGENT_DIR" add -A
     git -C "$HYPERAGENT_DIR" commit --author="Hyperagent <hyperagent@local>" \
         -m "[hyperagent] initial install"
+fi
+
+# --- Self-heal: untrack ephemeral state committed by older installs ---
+# A pre-existing tracked .heartbeat / ledger / .seen entry keeps
+# `git status` permanently dirty, which causes the watcher to invoke a
+# full meta-agent + changelog Claude session every cycle. Untrack any
+# tracked-but-gitignored paths so the watcher's dirty check converges
+# on meaningful changes.
+if [ -d "$HYPERAGENT_DIR/.git" ]; then
+    tracked_ignored=$(git -C "$HYPERAGENT_DIR" ls-files -ci --exclude-standard 2>/dev/null || true)
+    if [ -n "$tracked_ignored" ]; then
+        echo "Untracking ephemeral state files committed by an earlier install:"
+        printf '  %s\n' $tracked_ignored
+        # shellcheck disable=SC2086
+        git -C "$HYPERAGENT_DIR" rm --cached --quiet -r -- $tracked_ignored
+        git -C "$HYPERAGENT_DIR" commit --author="Hyperagent <hyperagent@local>" \
+            -m "[hyperagent] untrack ephemeral state (no-op-cycle fix)" \
+            >/dev/null 2>&1 || true
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
Closes #58.

## What was happening

The watcher's "did anything change?" check used raw `git status --porcelain`. When `.heartbeat` or `ledger` were tracked — by an older `.gitignore`, or by a stray `git add -A` — the repo was permanently dirty. Every 60-second poll cycle then:

1. Launched a meta agent Claude session (up to 20 transcripts of context).
2. Saw the still-dirty repo and launched a *second* Claude session to write a changelog entry.
3. Auto-committed the heartbeat tick, re-dirtying the repo for the next cycle.

The reporter measured ~692M tokens/week and five consecutive "No-op cycle" entries with identical reasoning.

## Fix

Two changes in `hyperagent-spec.md`:

- **§6 watcher.sh** — new `meaningful_changes()` helper strips porcelain output of the §2 `.gitignore` set (`.heartbeat`, `ledger`, `.lock`, `.last-check`, `.last-change`, `.last-upgrade-check`, `.upgrade-available`, `.last-upstream-poll`, `.seen/`, `discussions/`). Both the `commit_hyperagent_repo` gate and the `run_meta_agent` Phase 2 hyperagent dirty check route through it. The decision now reflects *intent*, not filesystem accident.
- **§10 install.sh** — adds a self-heal step: `git ls-files -ci --exclude-standard` finds any tracked-but-gitignored paths, untracks them, and commits the removal once. Existing installs converge to the corrected state on next install run.

The project-repo dirty check inside `run_meta_agent` is intentionally untouched — project repos hold no hyperagent state files, and filtering there would mask real edits.

## Scope notes

The reporter also flagged a `log()` / `/usr/bin/log` collision under launchd. The current spec defines no `log()` function — the watcher uses `echo` directly — so that symptom belongs to a divergent local hyperagent and is out of scope for this PR.

## Verification

The fix is in the spec; verification is performed against a generated hyperagent.

- [ ] Generate a hyperagent from this branch and confirm `meaningful_changes` is present in `watcher.sh`.
- [ ] On a hyperagent that has `.heartbeat` and `ledger` already tracked, run `install.sh` and confirm the self-heal commit lands and `git ls-files -ci --exclude-standard` returns empty.
- [ ] After a watcher cycle in which the meta agent makes no changes, confirm no `[hyperagent] auto-commit` lands and no `changelog.md` entry is appended.