### PR TITLE
Reassign copyright to Fort Asset LLC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Kerry Ivan Kurian
+Copyright (c) 2026 Fort Asset LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -189,4 +189,4 @@ That work ran on benchmarks. This runs on your work.
 
 ## License
 
-[MIT](LICENSE) © 2026 Kerry Ivan Kurian
+[MIT](LICENSE) © 2026 Fort Asset LLC, a Washington State limited liability company.


### PR DESCRIPTION
The MIT license body is unchanged. The copyright holder is now Fort Asset LLC, a Washington State limited liability company. The README footer is updated to match.

Worktree-local copies under `.claude/worktrees/` are not modified — they are agent snapshots and will converge on the new value as those worktrees are recreated.